### PR TITLE
prod-devel-rcar.yaml: Disable installation of the kernel inside the initrd

### DIFF
--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -166,7 +166,7 @@ components:
         - [INIT_MANAGER, "systemd"]
 
         # Do not install kernel image to rootfs to decrease initrd size
-        - ["RDEPENDS:${KERNEL_PACKAGE_NAME}-base", ""]
+        - ["RRECOMMENDS:${KERNEL_PACKAGE_NAME}-base", ""]
 
         # Build our own Xen version rather than proposed by meta-virtualization
         - [PREFERRED_VERSION_xen, "4.17.0+git%"]


### PR DESCRIPTION
In order to minimize the size of the initrd

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>