### PR TITLE
xen-tools: Disable installation of the python3-core inside initrd

### DIFF
--- a/meta-xt-domx-gen3/recipes-extended/xen/xen-tools_git.bbappend
+++ b/meta-xt-domx-gen3/recipes-extended/xen/xen-tools_git.bbappend
@@ -1,3 +1,6 @@
+# Avoid redundant runtime dependency on python3-core
+RDEPENDS:${PN}:remove:class-target = " ${PYTHON_PN}-core" 
+
 require xen-source.inc
 
 FILES:${PN}-test = "\

--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -173,7 +173,6 @@ components:
         - [PREFERRED_VERSION_xen-tools, "4.17.0+git%"]
 
         - [PACKAGE_EXCLUDE:append, " qemu"]
-        - [INITRAMFS_MAXSIZE, "163840"]
 
       layers:
         - "../meta-virtualization"


### PR DESCRIPTION
After switching from the Dunfel to the Kirkstone release of Yocto the
size of the Dom0 initramfs was drastically increased.

This commit is another step in direction of the initramfs size's
minimization.

The runtime dependency to the python3-core looks redundant. Thus, we
remove it.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>

----

prod-devel-rcar.yaml: Remove the custom INITRAMFS_MAXSIZE parameter

Usage of this parameter is not needed anymore, after the size of the
initramfs was reduced.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>