### PR TITLE
prod-devel-rcar.yaml: Remove strace from the build

### DIFF
--- a/prod-devel-rcar.yaml
+++ b/prod-devel-rcar.yaml
@@ -104,7 +104,7 @@ common_data:
     - [PACKAGE_CLASSES, "package_ipk"]
 
     # Additional testing and debug tools
-    - [IMAGE_INSTALL:append, " expect ltrace strace evtest"]
+    - [IMAGE_INSTALL:append, " expect ltrace evtest"]
 
     # Install some apps to test GPU/Display
     - [IMAGE_INSTALL:append, " glmark2 kmscube"]


### PR DESCRIPTION
It is causing a build error after switching to the new Renesas BSP 5.9.0 and Yocto Kirkstone:

../strace-5.10/v4l2.c:23:9: error: static assertion failed: "Unexpected struct v4l2_create_buffers.reserved size, please update the decoder"

If we will need this tool, we will investigate this issue later on.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>