### PR TITLE
Turn off displbe and sndbe services

### DIFF
--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/doma.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/doma.bbappend
@@ -6,13 +6,11 @@ SRC_URI += "\
     file://doma-vdevices.cfg \
     file://doma-set-root \
     file://doma-set-root.conf \
-    file://backends.conf \
 "
 
 FILES:${PN} += " \
     ${libdir}/xen/bin/doma-set-root \
     ${sysconfdir}/systemd/system/doma.service.d/doma-set-root.conf \
-    ${sysconfdir}/systemd/system/doma.service.d/backends.conf \
 "
 
 do_install:append() {
@@ -23,8 +21,4 @@ do_install:append() {
     install -m 0744 ${WORKDIR}/doma-set-root ${D}${libdir}/xen/bin
     install -d ${D}${sysconfdir}/systemd/system/doma.service.d
     install -m 0644 ${WORKDIR}/doma-set-root.conf ${D}${sysconfdir}/systemd/system/doma.service.d
-
-    # Install drop-in file to add dependencies on sndbe and displbe
-    # Directory is installed above for doma-set-root.conf
-    install -m 0644 ${WORKDIR}/backends.conf ${D}${sysconfdir}/systemd/system/doma.service.d
 }

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/backends.conf
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/doma/files/backends.conf
@@ -1,3 +1,0 @@
-[Unit]
-Requires=backend-ready@displbe.service backend-ready@sndbe.service
-After=backend-ready@displbe.service backend-ready@sndbe.service

--- a/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
+++ b/meta-xt-prod-devel-rcar-control/recipes-guests/domu/domu.bbappend
@@ -19,8 +19,6 @@ do_install:append() {
 
     if ${@bb.utils.contains('DISTRO_FEATURES', 'pvcamera', 'true', 'false', d)}; then
         #cat ${WORKDIR}/domu-pvcamera.cfg >> ${CFG_FILE}
-        # Update GUEST_DEPENDENCIES by adding camerabe after sndbe
-        sed -i 's/\<sndbe\>/& camerabe/' ${D}${sysconfdir}/init.d/guest_domu
         echo "[Unit]" >> ${D}${systemd_unitdir}/system/domu.service
         echo "Requires=backend-ready@camerabe.service" >> ${D}${systemd_unitdir}/system/domu.service
         echo "After=backend-ready@camerabe.service" >> ${D}${systemd_unitdir}/system/domu.service
@@ -32,7 +30,7 @@ do_install:append() {
         # Update root by changing xvda1 to vda
         sed -i 's/root=\/dev\/xvda1/root=\/dev\/vda/' ${CFG_FILE}
 
-        # Update GUEST_DEPENDENCIES by adding virtio-disk after sndbe
+        # Update GUEST_DEPENDENCIES by adding dependency to the virtio
         echo "[Unit]" >> ${D}${systemd_unitdir}/system/domu.service
         echo "Requires=backend-ready@virtio.service" >> ${D}${systemd_unitdir}/system/domu.service
         echo "After=backend-ready@virtio.service" >> ${D}${systemd_unitdir}/system/domu.service

--- a/meta-xt-prod-devel-rcar-driver-domain/recipes-graphics/images/core-image-weston.bbappend
+++ b/meta-xt-prod-devel-rcar-driver-domain/recipes-graphics/images/core-image-weston.bbappend
@@ -1,5 +1,4 @@
 IMAGE_INSTALL:append = " \
-    sndbe \
     ${@bb.utils.contains('DISTRO_FEATURES', 'pvcamera', 'camerabe', '', d)} \
     ${@bb.utils.contains('DISTRO_FEATURES', 'vis', 'aos-vis', '', d)} \
 "


### PR DESCRIPTION
For virtio-based product, there is no need in the displbe.service and sndbe.service systemd units. They are redundant in our context.

This patch turns off the compilation and installation of those services.

Also, it excludes them as a dependency for the other systemd services.

Signed-off-by: Vladyslav Goncharuk <vladyslav_goncharuk@epam.com>